### PR TITLE
Add a function to get a pointer to the inner polyanya::Mesh.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,10 @@ impl PathMesh {
         }
     }
 
+    pub fn get(&self) -> Arc<polyanya::Mesh> {
+        self.mesh.clone()
+    }
+
     #[inline]
     pub async fn get_path(&self, from: Vec2, to: Vec2) -> Option<polyanya::Path> {
         self.mesh.get_path(from, to).await


### PR DESCRIPTION
This is useful for debugging without having to store a second copy of the polyanya Mesh.

It would also be nice to be able to get a mutable reference to the inner polyanya mesh for eg. updating the mesh without having to clone it first, but that would require wrapping it in a mutex or Rwlock or something.