### PR TITLE
Support import from bevy mesh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-polyanya = "0.2"
+polyanya = { git = "https://github.com/janhohenheim/polyanya.git", branch = "import-trimesh" }
+itertools = "0.10.5"
 
 [dependencies.bevy]
 version = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-polyanya = { git = "https://github.com/vleue/polyanya.git" }
+polyanya = "0.2.1"
 itertools = "0.10.5"
 
 [dependencies.bevy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-polyanya = { git = "https://github.com/janhohenheim/polyanya.git", branch = "import-trimesh" }
+polyanya = { git = "https://github.com/vleue/polyanya.git" }
 itertools = "0.10.5"
 
 [dependencies.bevy]

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -1,5 +1,5 @@
 use bevy::{prelude::*, sprite::MaterialMesh2dBundle, window::WindowResized};
-use bevy_pathmesh::{PathMesh, PathmeshPlugin};
+use bevy_pathmesh::{PathMesh, PathMeshPlugin};
 use bevy_prototype_debug_lines::{DebugLines, DebugLinesPlugin};
 
 fn main() {
@@ -14,7 +14,7 @@ fn main() {
             ..default()
         }))
         .add_plugin(DebugLinesPlugin::default())
-        .add_plugin(PathmeshPlugin)
+        .add_plugin(PathMeshPlugin)
         .add_event::<NewPathStepEvent>()
         .insert_resource(PathToDisplay::default())
         .add_startup_system(setup)

--- a/examples/many.rs
+++ b/examples/many.rs
@@ -17,7 +17,7 @@ use bevy::{
 };
 use rand::prelude::*;
 
-use bevy_pathmesh::{PathMesh, PathmeshPlugin};
+use bevy_pathmesh::{PathMesh, PathMeshPlugin};
 use bevy_prototype_debug_lines::{DebugLines, DebugLinesPlugin};
 
 fn main() {
@@ -46,7 +46,7 @@ fn main() {
                 }),
         )
         .add_plugin(DebugLinesPlugin::default())
-        .add_plugin(PathmeshPlugin)
+        .add_plugin(PathMeshPlugin)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .init_resource::<Stats>()

--- a/examples/moving.rs
+++ b/examples/moving.rs
@@ -8,7 +8,7 @@ use bevy::{
     window::WindowResized,
 };
 
-use bevy_pathmesh::{PathMesh, PathmeshPlugin};
+use bevy_pathmesh::{PathMesh, PathMeshPlugin};
 use bevy_prototype_debug_lines::{DebugLines, DebugLinesPlugin};
 
 fn main() {
@@ -23,7 +23,7 @@ fn main() {
             ..default()
         }))
         .add_plugin(DebugLinesPlugin::default())
-        .add_plugin(PathmeshPlugin)
+        .add_plugin(PathMeshPlugin)
         .add_startup_system(setup)
         .add_system(on_mesh_change)
         .add_system(mesh_change)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub struct PathMesh {
 }
 
 impl PathMesh {
-    pub fn from_polyanya_mesh(mut mesh: polyanya::Mesh) -> PathMesh {
+    pub fn from_polyanya_mesh(mesh: polyanya::Mesh) -> PathMesh {
         PathMesh {
             mesh: Arc::new(mesh),
             transform: Transform::from_scale(Vec3::splat(1.)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ impl PathMesh {
 
         let vertices = get_vectors(mesh, Mesh::ATTRIBUTE_POSITION)
             .map(|vertex| rotation.mul_vec3(vertex))
-            .map(|coords| Vec2::new(coords[0], coords[1]))
+            .map(|coords| coords.xy())
             .collect();
 
         let triangles = mesh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ pub struct PathMesh {
 
 impl PathMesh {
     pub fn from_polyanya_mesh(mut mesh: polyanya::Mesh) -> PathMesh {
-        mesh.bake();
         PathMesh {
             mesh: Arc::new(mesh),
             transform: Transform::from_scale(Vec3::splat(1.)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,8 @@ pub struct PathMesh {
 }
 
 impl PathMesh {
-    pub fn from_polyanya_mesh(mesh: polyanya::Mesh) -> PathMesh {
+    pub fn from_polyanya_mesh(mut mesh: polyanya::Mesh) -> PathMesh {
+        mesh.bake();
         PathMesh {
             mesh: Arc::new(mesh),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@ use bevy::{
 };
 use itertools::Itertools;
 
-pub struct PathmeshPlugin;
+pub struct PathMeshPlugin;
 
-impl Plugin for PathmeshPlugin {
+impl Plugin for PathMeshPlugin {
     fn build(&self, app: &mut App) {
         app.add_asset::<PathMesh>()
             .init_asset_loader::<PathMeshPolyanyaLoader>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,6 @@ impl PathMesh {
                     (2..p.vertices.len())
                         .flat_map(|i| [p.vertices[0], p.vertices[i - 1], p.vertices[i]])
                 })
-                .map(|v| v as u32)
                 .collect(),
         )));
         new_mesh.insert_attribute(
@@ -218,7 +217,7 @@ fn get_vectors(
         // Guaranteed by Bevy
         _ => unreachable!(),
     };
-    vectors.into_iter().cloned().map(Vec3::from)
+    vectors.iter().cloned().map(Vec3::from)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ impl PathMesh {
         }
     }
 
+    /// Creates a `PathMesh` from a Bevy `Mesh`, assuming it constructs a 2D structure.
+    /// All y coordinates are ignored.
     pub fn from_bevy_mesh(mesh: Mesh) -> PathMesh {
         assert_eq!(mesh.primitive_topology(), PrimitiveTopology::TriangleList);
         let mesh_vertices = match mesh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ impl PathMesh {
     ///
     /// Returns the generated [`PathMesh`] and a [`bevy::Transform`] that describes how to go
     /// from the [`bevy::Mesh`] space to the [`PathMesh`] space.
+    /// After the transform, the `z` coordinate can be dropped since the [`PathMesh`] is 2D.
     ///
     /// Only supports triangle lists.
     pub fn from_bevy_mesh_and_then(
@@ -73,6 +74,7 @@ impl PathMesh {
     ///
     /// Returns the generated [`PathMesh`] and a [`bevy::Transform`] that describes how to go
     /// from the [`bevy::Mesh`] space to the [`PathMesh`] space.
+    /// After the transform, the `z` coordinate can be dropped since the [`PathMesh`] is 2D.
     ///
     /// Only supports triangle lists.
     pub fn from_bevy_mesh(mesh: &Mesh) -> (PathMesh, Transform) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@ impl PathMesh {
         }
     }
 
-    /// Creates a `PathMesh` from a Bevy `Mesh`, assuming it constructs a 2D structure.
+    /// Creates a [`polyanya::PathMesh`] from a Bevy [`Mesh`], assuming it constructs a 2D structure.
+    /// All triangle normals are aligned during the conversion, so the orientation of the [`Mesh`] does not matter.
+    ///
     /// Only supports triangle lists.
     pub fn from_bevy_mesh(mesh: &Mesh) -> PathMesh {
         println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,10 +186,14 @@ mod tests {
         let bevy_mesh = expected_path_mesh.to_mesh();
         let actual_path_mesh = PathMesh::from_bevy_mesh(&bevy_mesh);
 
-        let expected_mesh = expected_path_mesh.mesh;
-        let actual_mesh = actual_path_mesh.mesh;
+        assert_same_path_mesh(expected_path_mesh, actual_path_mesh);
+    }
 
-        assert_eq!(actual_mesh.polygons, expected_mesh.polygons);
+    fn assert_same_path_mesh(expected: PathMesh, actual: PathMesh) {
+        let expected_mesh = expected.mesh;
+        let actual_mesh = actual.mesh;
+
+        assert_eq!(expected_mesh.polygons, actual_mesh.polygons);
         for (index, (expected_vertex, actual_vertex)) in expected_mesh
             .vertices
             .iter()


### PR DESCRIPTION
- Fixes #7 
- Fixes #9, but I can remove it again if you disagree.
- Fixes a naming inconsistency: Renamed `PathmeshPlugin` to `PathMeshPlugin` to be consistent with the `PathMesh` type.

This PR is nearly done, but waiting for https://github.com/vleue/polyanya/pull/21 to be merged
- [x] point to vleue's `polyanya`
- [x] internally store transform