### PR TITLE
chore: release v0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vleue_navigator"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["François Mockers <francois.mockers@vleue.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `vleue_navigator`: 0.12.0 -> 0.13.0 (⚠ API breaking changes)

### ⚠ `vleue_navigator` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NavMeshSettings.ignore_obstacles in /tmp/.tmpbuWSCs/vleue_navigator/src/updater.rs:134
```

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).