### PR TITLE
Add rand::prelude use statement to fix avian3d example build

### DIFF
--- a/examples/auto_navmesh_avian3d.rs
+++ b/examples/auto_navmesh_avian3d.rs
@@ -5,6 +5,7 @@ use bevy::{
     asset::uuid_handle, color::palettes, math::vec2, prelude::*, time::common_conditions::on_timer,
 };
 
+use rand::prelude::*;
 use vleue_navigator::prelude::*;
 
 #[derive(Component)]
@@ -98,8 +99,6 @@ fn setup(
 
     let obstacle_size = 2.0;
     let spacing = 1.0;
-
-    use rand::seq::SliceRandom;
 
     let types = [
         (


### PR DESCRIPTION
Hello,

First of all thanks for your great crate and your work! 
When playing with the avian examples, I noticed the `auto_navmesh_avian3d` does not build on my machine (x86 Linux).

Using another rand use statement makes it build and run.