### PR TITLE
Update to Bevy 0.19 and Avian 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vleue_navigator"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["François Mockers <francois.mockers@vleue.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -16,15 +16,16 @@ categories = ["game-development"]
 itertools = "0.14"
 tracing = { version = "0.1", optional = true }
 log = "0.4.27"
+polyanya_glam = { package = "glam", version = "0.30.8" }
 
 [dependencies.avian2d]
-version = "0.5"
+version = "0.7"
 features = ["2d", "f32", "parry-f32"]
 default-features = false
 optional = true
 
 [dependencies.avian3d]
-version = "0.5"
+version = "0.7"
 features = ["3d", "f32", "parry-f32"]
 default-features = false
 optional = true
@@ -33,7 +34,7 @@ optional = true
 version = "0.16.0"
 
 [dependencies.bevy]
-version = "0.18.0"
+version = "0.19.0"
 features = ["bevy_render", "bevy_asset", "bevy_log"]
 default-features = false
 
@@ -47,7 +48,7 @@ version = "0.16.0"
 features = ["serde"]
 
 [dev-dependencies.bevy]
-version = "0.18.0"
+version = "0.19.0"
 
 [features]
 default = ["debug-with-gizmos"]

--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ NavMesh building:
 
 ### To Implement
 
-- Steering Behaviors For Autonomous Characters https://www.red3d.com/cwr/steer/
+- Steering Behaviors For Autonomous Characters <https://www.red3d.com/cwr/steer/>
 
 ## Bevy Supported Versions
 
 | Bevy | vleue_navigator | avian |
 | ---- | --------------- | ----- |
+| 0.19 | 0.16            | 0.7   |
 | 0.18 | 0.15            | 0.5   |
 | 0.17 | 0.14            | 0.4   |
 | 0.16 | 0.13            | 0.3   |

--- a/examples/auto_navmesh_aabb.rs
+++ b/examples/auto_navmesh_aabb.rs
@@ -1,7 +1,6 @@
 use bevy::{
     camera::primitives::Aabb,
     color::palettes,
-    math::vec2,
     prelude::*,
     sprite_render::ColorMaterial,
     window::{PrimaryWindow, WindowResized},
@@ -78,10 +77,10 @@ fn setup(mut commands: Commands) {
         NavMeshSettings {
             // Define the outer borders of the navmesh.
             fixed: Triangulation::from_outer_edges(&[
-                vec2(0.0, 0.0),
-                vec2(MESH_WIDTH as f32, 0.0),
-                vec2(MESH_WIDTH as f32, MESH_HEIGHT as f32),
-                vec2(0.0, MESH_HEIGHT as f32),
+                nav_vec2(0.0, 0.0),
+                nav_vec2(MESH_WIDTH as f32, 0.0),
+                nav_vec2(MESH_WIDTH as f32, MESH_HEIGHT as f32),
+                nav_vec2(0.0, MESH_HEIGHT as f32),
             ]),
             ..default()
         },

--- a/examples/auto_navmesh_avian2d.rs
+++ b/examples/auto_navmesh_avian2d.rs
@@ -1,5 +1,5 @@
 use avian2d::{math::*, prelude::*};
-use bevy::{color::palettes, math::vec2, prelude::*, sprite_render::ColorMaterial};
+use bevy::{color::palettes, prelude::*, sprite_render::ColorMaterial};
 use rand::Rng;
 use vleue_navigator::prelude::*;
 
@@ -73,7 +73,7 @@ fn setup(
     for x in (-50..50).step_by(step).skip(1) {
         for (yi, y) in (-50..50).step_by(step).skip(1).enumerate() {
             commands.spawn((
-                Mesh2d(peg_mesh.clone().into()),
+                Mesh2d(peg_mesh.clone()),
                 MeshMaterial2d(peg_material.clone()),
                 Transform::from_xyz(
                     (x as f32
@@ -99,7 +99,7 @@ fn setup(
     for x in (-50..50).step_by(5).skip(1) {
         let start = Vec3::new(x as f32 * 9.5, 300.0, 0.0);
         commands.spawn((
-            Mesh2d(marble_mesh.clone().into()),
+            Mesh2d(marble_mesh.clone()),
             MeshMaterial2d(marble_material.clone()),
             Transform::from_translation(start),
             RigidBody::Dynamic,
@@ -120,10 +120,10 @@ fn setup(
         NavMeshSettings {
             // Define the outer borders of the navmesh.
             fixed: Triangulation::from_outer_edges(&[
-                vec2(-500.0, -500.0),
-                vec2(500.0, -500.0),
-                vec2(500.0, 500.0),
-                vec2(-500.0, 500.0),
+                nav_vec2(-500.0, -500.0),
+                nav_vec2(500.0, -500.0),
+                nav_vec2(500.0, 500.0),
+                nav_vec2(-500.0, 500.0),
             ]),
             agent_radius: 5.0,
             simplify: 4.0,
@@ -184,10 +184,10 @@ pub fn move_puck(
         let move_direction = path.current - transform.translation;
         transform.translation += move_direction.normalize() * time.delta_secs() * 100.0;
 
-        if transform.translation.distance(path.current) < 10.0 {
-            if let Some(next) = path.next.pop() {
-                path.current = next;
-            }
+        if transform.translation.distance(path.current) < 10.0
+            && let Some(next) = path.next.pop()
+        {
+            path.current = next;
         }
         if transform.translation.distance(path.current) < 50.0 && path.next.is_empty() {
             commands

--- a/examples/auto_navmesh_avian3d.rs
+++ b/examples/auto_navmesh_avian3d.rs
@@ -1,9 +1,7 @@
 use std::time::Duration;
 
 use avian3d::{math::*, prelude::*};
-use bevy::{
-    asset::uuid_handle, color::palettes, math::vec2, prelude::*, time::common_conditions::on_timer,
-};
+use bevy::{asset::uuid_handle, color::palettes, prelude::*, time::common_conditions::on_timer};
 
 use rand::prelude::*;
 use vleue_navigator::prelude::*;
@@ -143,7 +141,7 @@ fn setup(
     commands.spawn((
         DirectionalLight {
             illuminance: 5000.0,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
@@ -163,10 +161,10 @@ fn setup(
             NavMeshSettings {
                 // Define the outer borders of the navmesh.
                 fixed: Triangulation::from_outer_edges(&[
-                    vec2(-25.0, -25.0),
-                    vec2(25.0, -25.0),
-                    vec2(25.0, 25.0),
-                    vec2(-25.0, 25.0),
+                    nav_vec2(-25.0, -25.0),
+                    nav_vec2(25.0, -25.0),
+                    nav_vec2(25.0, 25.0),
+                    nav_vec2(-25.0, 25.0),
                 ]),
                 build_timeout: Some(1.0),
                 simplify: 0.005,

--- a/examples/auto_navmesh_avian3d_inclined.rs
+++ b/examples/auto_navmesh_avian3d_inclined.rs
@@ -1,9 +1,7 @@
 use std::{f32::consts::FRAC_PI_8, time::Duration};
 
 use avian3d::{math::*, prelude::*};
-use bevy::{
-    asset::uuid_handle, color::palettes, math::vec2, prelude::*, time::common_conditions::on_timer,
-};
+use bevy::{asset::uuid_handle, color::palettes, prelude::*, time::common_conditions::on_timer};
 
 use rand::Rng;
 use vleue_navigator::prelude::*;
@@ -66,7 +64,7 @@ fn setup(
     commands.spawn((
         DirectionalLight {
             illuminance: 5000.0,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
@@ -82,10 +80,10 @@ fn setup(
         NavMeshSettings {
             // Define the outer borders of the navmesh.
             fixed: Triangulation::from_outer_edges(&[
-                vec2(-25.0, -25.0),
-                vec2(25.0, -25.0),
-                vec2(25.0, 25.0),
-                vec2(-25.0, 25.0),
+                nav_vec2(-25.0, -25.0),
+                nav_vec2(25.0, -25.0),
+                nav_vec2(25.0, 25.0),
+                nav_vec2(-25.0, 25.0),
             ]),
             build_timeout: Some(1.0),
             simplify: 0.005,

--- a/examples/auto_navmesh_primitive.rs
+++ b/examples/auto_navmesh_primitive.rs
@@ -76,10 +76,10 @@ fn setup(mut commands: Commands) {
             // Define the outer borders of the navmesh.
             // This will be in navmesh coordinates
             fixed: Triangulation::from_outer_edges(&[
-                vec2(0.0, 0.0),
-                vec2(MESH_WIDTH as f32, 0.0),
-                vec2(MESH_WIDTH as f32, MESH_HEIGHT as f32),
-                vec2(0.0, MESH_HEIGHT as f32),
+                nav_vec2(0.0, 0.0),
+                nav_vec2(MESH_WIDTH as f32, 0.0),
+                nav_vec2(MESH_WIDTH as f32, MESH_HEIGHT as f32),
+                nav_vec2(0.0, MESH_HEIGHT as f32),
             ]),
             // Starting with a small mesh simplification factor to avoid very small geometry.
             // Small geometry can make navmesh generation fail due to rounding errors.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -158,12 +158,8 @@ fn life_of_obstacle(
             if cachable.remove(&entity) {
                 commands.entity(entity).remove::<CachableObstacle>();
             }
-        } else {
-            if example_settings.cache_enabled {
-                if cachable.insert(entity) {
-                    commands.entity(entity).insert(CachableObstacle);
-                }
-            }
+        } else if example_settings.cache_enabled && cachable.insert(entity) {
+            commands.entity(entity).insert(CachableObstacle);
         }
     }
 }
@@ -208,7 +204,7 @@ fn setup(mut commands: Commands, mut materials: ResMut<Assets<StandardMaterial>>
     for (x, y) in [(0.25, 0.25), (0.75, 0.25), (0.25, 0.75), (0.75, 0.75)] {
         commands.spawn((
             PointLight {
-                shadows_enabled: true,
+                shadow_maps_enabled: true,
                 intensity: MESH_WIDTH.min(MESH_HEIGHT) as f32 * 300_000.0,
                 range: MESH_WIDTH.min(MESH_HEIGHT) as f32 * 10.0,
                 ..default()
@@ -226,10 +222,10 @@ fn setup(mut commands: Commands, mut materials: ResMut<Assets<StandardMaterial>>
         NavMeshSettings {
             // Define the outer borders of the navmesh.
             fixed: Triangulation::from_outer_edges(&[
-                vec2(0.0, 0.0),
-                vec2(MESH_WIDTH as f32, 0.0),
-                vec2(MESH_WIDTH as f32, MESH_HEIGHT as f32),
-                vec2(0.0, MESH_HEIGHT as f32),
+                nav_vec2(0.0, 0.0),
+                nav_vec2(MESH_WIDTH as f32, 0.0),
+                nav_vec2(MESH_WIDTH as f32, MESH_HEIGHT as f32),
+                nav_vec2(0.0, MESH_HEIGHT as f32),
             ]),
             simplify: 0.1,
             merge_steps: 1,

--- a/examples/gltf.rs
+++ b/examples/gltf.rs
@@ -73,7 +73,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Camera3d::default(),
         Camera::default(),
         #[cfg(not(target_arch = "wasm32"))]
-        bevy::render::view::Hdr,
+        bevy::camera::Hdr,
         Transform::from_xyz(0.0, 70.0, 5.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
     ));
 
@@ -88,7 +88,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         ))
         .with_children(|p| {
             let font_size = TextFont {
-                font_size: 20.0,
+                font_size: 20.0.into(),
                 ..default()
             };
             p.spawn((
@@ -184,7 +184,7 @@ fn setup_scene(
                 SpotLight {
                     intensity: 1000000.0,
                     color: palettes::css::SEA_GREEN.into(),
-                    shadows_enabled: true,
+                    shadow_maps_enabled: true,
                     inner_angle: 0.5,
                     outer_angle: 0.8,
                     range: 250.0,
@@ -252,7 +252,7 @@ fn setup_scene(
                         color: palettes::css::BLUE.into(),
                         range: 500.0,
                         intensity: 100000.0,
-                        shadows_enabled: true,
+                        shadow_maps_enabled: true,
                         ..default()
                     },
                     Transform::from_xyz(0.0, 1.2, 0.0),
@@ -305,7 +305,7 @@ fn give_target_auto(
                     target.spawn((
                         PointLight {
                             color: palettes::css::RED.into(),
-                            shadows_enabled: true,
+                            shadow_maps_enabled: true,
                             range: 10.0,
                             ..default()
                         },
@@ -322,6 +322,7 @@ fn give_target_auto(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn give_target_on_click(
     mut commands: Commands,
     mut object_query: Query<(Entity, &Transform, &mut Object)>,
@@ -371,7 +372,7 @@ fn give_target_on_click(
                         target.spawn((
                             PointLight {
                                 color: palettes::css::RED.into(),
-                                shadows_enabled: true,
+                                shadow_maps_enabled: true,
                                 range: 10.0,
                                 ..default()
                             },

--- a/examples/gltf_avian3d.rs
+++ b/examples/gltf_avian3d.rs
@@ -94,7 +94,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         DirectionalLight {
             illuminance: 3000.0,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
@@ -212,7 +212,7 @@ fn setup_scene(
                         color: palettes::css::BLUE.into(),
                         range: 500.0,
                         intensity: 100000.0,
-                        shadows_enabled: true,
+                        shadow_maps_enabled: true,
                         ..default()
                     },
                     Transform::from_xyz(0.0, 1.2, 0.0),
@@ -267,7 +267,7 @@ fn give_target_auto(
                     target.spawn((
                         PointLight {
                             color: palettes::css::RED.into(),
-                            shadows_enabled: true,
+                            shadow_maps_enabled: true,
                             range: 10.0,
                             ..default()
                         },

--- a/examples/helpers/agent2d.rs
+++ b/examples/helpers/agent2d.rs
@@ -29,6 +29,7 @@ pub fn setup_agent<const SIZE: u32>(mut commands: Commands) {
     ));
 }
 
+#[allow(clippy::type_complexity)]
 pub fn give_target_to_navigator<const SIZE: u32, const X: u32, const Y: u32>(
     mut commands: Commands,
     navigator: Query<(Entity, &Transform), (With<Navigator>, Without<Path>)>,
@@ -95,7 +96,7 @@ pub fn refresh_path<const SIZE: u32, const X: u32, const Y: u32>(
     if (!status.is_changed() || **status != NavMeshStatus::Built) && *delta == 0.0 {
         return;
     }
-    let Some(navmesh) = navmeshes.get_mut(*navmesh_handle) else {
+    let Some(mut navmesh) = navmeshes.get_mut(*navmesh_handle) else {
         return;
     };
 

--- a/examples/helpers/agent3d.rs
+++ b/examples/helpers/agent3d.rs
@@ -132,7 +132,7 @@ pub fn refresh_path<const X: u32, const Y: u32>(
     if (!status.is_changed() || **status != NavMeshStatus::Built) && deltas.is_empty() {
         return;
     }
-    let Some(navmesh) = navmeshes.get_mut(*navmesh_handle) else {
+    let Some(mut navmesh) = navmeshes.get_mut(*navmesh_handle) else {
         return;
     };
 

--- a/examples/helpers/camera_controller.rs
+++ b/examples/helpers/camera_controller.rs
@@ -124,6 +124,7 @@ Freecam Controls:
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_camera_controller(
     time: Res<Time>,
     mut windows: Query<(&mut Window, &mut CursorOptions)>,

--- a/examples/helpers/ui.rs
+++ b/examples/helpers/ui.rs
@@ -49,7 +49,7 @@ fn button(text: &str, action: UiSettingsButtons, parent: &mut ChildSpawnerComman
             parent.spawn((
                 Text(text.to_string()),
                 TextFont {
-                    font_size: 20.0,
+                    font_size: 20.0.into(),
                     ..default()
                 },
             ));
@@ -81,7 +81,7 @@ pub fn setup_settings<const WITH_CACHE: bool>(mut commands: Commands) {
                     .spawn((
                         Text("Simplify: ".to_string()),
                         TextFont {
-                            font_size: 20.0,
+                            font_size: 20.0.into(),
                             ..default()
                         },
                         TextLayout {
@@ -93,7 +93,7 @@ pub fn setup_settings<const WITH_CACHE: bool>(mut commands: Commands) {
                     .with_child((
                         TextSpan::default(),
                         TextFont {
-                            font_size: 20.0,
+                            font_size: 20.0.into(),
                             ..default()
                         },
                     ));
@@ -105,7 +105,7 @@ pub fn setup_settings<const WITH_CACHE: bool>(mut commands: Commands) {
                     .spawn((
                         Text("Merge Steps: ".to_string()),
                         TextFont {
-                            font_size: 20.0,
+                            font_size: 20.0.into(),
                             ..default()
                         },
                         TextLayout {
@@ -117,7 +117,7 @@ pub fn setup_settings<const WITH_CACHE: bool>(mut commands: Commands) {
                     .with_child((
                         TextSpan::default(),
                         TextFont {
-                            font_size: 20.0,
+                            font_size: 20.0.into(),
                             ..default()
                         },
                     ));
@@ -129,7 +129,7 @@ pub fn setup_settings<const WITH_CACHE: bool>(mut commands: Commands) {
                     .spawn((
                         Text("Agent Radius: ".to_string()),
                         TextFont {
-                            font_size: 20.0,
+                            font_size: 20.0.into(),
                             ..default()
                         },
                         TextLayout {
@@ -141,7 +141,7 @@ pub fn setup_settings<const WITH_CACHE: bool>(mut commands: Commands) {
                     .with_child((
                         TextSpan::default(),
                         TextFont {
-                            font_size: 20.0,
+                            font_size: 20.0.into(),
                             ..default()
                         },
                     ));
@@ -169,7 +169,7 @@ pub fn setup_settings<const WITH_CACHE: bool>(mut commands: Commands) {
                     parent.spawn((
                         Text("Agent Radius on Outer Edges".to_string()),
                         TextFont {
-                            font_size: 20.0,
+                            font_size: 20.0.into(),
                             ..default()
                         },
                     ));
@@ -195,7 +195,7 @@ pub fn setup_settings<const WITH_CACHE: bool>(mut commands: Commands) {
                         parent.spawn((
                             Text("Cache".to_string()),
                             TextFont {
-                                font_size: 20.0,
+                                font_size: 20.0.into(),
                                 ..default()
                             },
                         ));
@@ -257,6 +257,7 @@ pub fn display_settings(
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub fn update_settings<const STEP: u32>(
     mut interaction_query: Query<
         (
@@ -358,7 +359,7 @@ pub fn setup_stats<const INTERACTIVE: bool>(mut commands: Commands) {
                     p.spawn((
                         TextSpan::new(text),
                         TextFont {
-                            font_size,
+                            font_size: font_size.into(),
                             ..default()
                         },
                     ));

--- a/examples/layers.rs
+++ b/examples/layers.rs
@@ -115,7 +115,7 @@ fn setup(
     commands.spawn((
         DirectionalLight {
             illuminance: 3000.0,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
@@ -131,17 +131,17 @@ fn setup(
             p.spawn((
                 NavMeshSettings {
                     fixed: Triangulation::from_outer_edges(&[
-                        vec2(-(MESH_UNIT as f32 / 2.0), MESH_UNIT as f32 * 2.0),
-                        vec2(MESH_UNIT as f32 * 2.5, MESH_UNIT as f32 * 2.0),
-                        vec2(MESH_UNIT as f32 * 2.5, MESH_UNIT as f32 * 2.5),
-                        vec2(MESH_UNIT as f32 * 2.5, MESH_UNIT as f32 * 3.5),
-                        vec2(MESH_UNIT as f32 * 3.5, MESH_UNIT as f32 * 3.5),
-                        vec2(MESH_UNIT as f32 * 3.5, MESH_UNIT as f32 * 1.0),
-                        vec2(MESH_UNIT as f32 * 2.5, MESH_UNIT as f32 * 1.0),
-                        vec2(MESH_UNIT as f32 / 2.0, MESH_UNIT as f32 * 1.0),
-                        vec2(MESH_UNIT as f32 / 2.0, MESH_UNIT as f32 / 2.0),
-                        vec2(MESH_UNIT as f32 / 2.0, -(MESH_UNIT as f32 / 2.0)),
-                        vec2(-(MESH_UNIT as f32) / 2.0, -(MESH_UNIT as f32 / 2.0)),
+                        nav_vec2(-(MESH_UNIT as f32 / 2.0), MESH_UNIT as f32 * 2.0),
+                        nav_vec2(MESH_UNIT as f32 * 2.5, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(MESH_UNIT as f32 * 2.5, MESH_UNIT as f32 * 2.5),
+                        nav_vec2(MESH_UNIT as f32 * 2.5, MESH_UNIT as f32 * 3.5),
+                        nav_vec2(MESH_UNIT as f32 * 3.5, MESH_UNIT as f32 * 3.5),
+                        nav_vec2(MESH_UNIT as f32 * 3.5, MESH_UNIT as f32 * 1.0),
+                        nav_vec2(MESH_UNIT as f32 * 2.5, MESH_UNIT as f32 * 1.0),
+                        nav_vec2(MESH_UNIT as f32 / 2.0, MESH_UNIT as f32 * 1.0),
+                        nav_vec2(MESH_UNIT as f32 / 2.0, MESH_UNIT as f32 / 2.0),
+                        nav_vec2(MESH_UNIT as f32 / 2.0, -(MESH_UNIT as f32 / 2.0)),
+                        nav_vec2(-(MESH_UNIT as f32) / 2.0, -(MESH_UNIT as f32 / 2.0)),
                     ]),
                     simplify: 0.001,
                     merge_steps: 2,
@@ -214,12 +214,12 @@ fn setup(
             p.spawn((
                 NavMeshSettings {
                     fixed: Triangulation::from_outer_edges(&[
-                        vec2(-(MESH_UNIT as f32 / 2.0), -(MESH_UNIT as f32 * 1.0)),
-                        vec2(-(MESH_UNIT as f32 / 2.0), MESH_UNIT as f32 * 2.0),
-                        vec2(MESH_UNIT as f32 / 2.0, MESH_UNIT as f32 * 2.0),
-                        vec2(MESH_UNIT as f32 / 2.0, MESH_UNIT as f32),
-                        vec2(MESH_UNIT as f32 / 2.0, -(MESH_UNIT as f32 * 2.0)),
-                        vec2(-(MESH_UNIT as f32 / 2.0), -(MESH_UNIT as f32 * 2.0)),
+                        nav_vec2(-(MESH_UNIT as f32 / 2.0), -(MESH_UNIT as f32 * 1.0)),
+                        nav_vec2(-(MESH_UNIT as f32 / 2.0), MESH_UNIT as f32 * 2.0),
+                        nav_vec2(MESH_UNIT as f32 / 2.0, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(MESH_UNIT as f32 / 2.0, MESH_UNIT as f32),
+                        nav_vec2(MESH_UNIT as f32 / 2.0, -(MESH_UNIT as f32 * 2.0)),
+                        nav_vec2(-(MESH_UNIT as f32 / 2.0), -(MESH_UNIT as f32 * 2.0)),
                     ]),
                     simplify: 0.001,
                     merge_steps: 2,
@@ -261,10 +261,10 @@ fn setup(
             p.spawn((
                 NavMeshSettings {
                     fixed: Triangulation::from_outer_edges(&[
-                        vec2(-(MESH_UNIT as f32 / 4.0), -(MESH_UNIT as f32 / 2.0)),
-                        vec2(MESH_UNIT as f32 / 4.0, -(MESH_UNIT as f32 / 2.0)),
-                        vec2(MESH_UNIT as f32 / 4.0, MESH_UNIT as f32 / 2.0),
-                        vec2(-(MESH_UNIT as f32 / 4.0), MESH_UNIT as f32 / 2.0),
+                        nav_vec2(-(MESH_UNIT as f32 / 4.0), -(MESH_UNIT as f32 / 2.0)),
+                        nav_vec2(MESH_UNIT as f32 / 4.0, -(MESH_UNIT as f32 / 2.0)),
+                        nav_vec2(MESH_UNIT as f32 / 4.0, MESH_UNIT as f32 / 2.0),
+                        nav_vec2(-(MESH_UNIT as f32 / 4.0), MESH_UNIT as f32 / 2.0),
                     ]),
                     simplify: 0.001,
                     merge_steps: 2,
@@ -313,10 +313,10 @@ fn setup(
             p.spawn((
                 NavMeshSettings {
                     fixed: Triangulation::from_outer_edges(&[
-                        vec2(-(MESH_UNIT as f32 / 4.0), -(MESH_UNIT as f32 / 2.0)),
-                        vec2(MESH_UNIT as f32 / 4.0, -(MESH_UNIT as f32 / 2.0)),
-                        vec2(MESH_UNIT as f32 / 4.0, MESH_UNIT as f32 / 2.0),
-                        vec2(-(MESH_UNIT as f32 / 4.0), MESH_UNIT as f32 / 2.0),
+                        nav_vec2(-(MESH_UNIT as f32 / 4.0), -(MESH_UNIT as f32 / 2.0)),
+                        nav_vec2(MESH_UNIT as f32 / 4.0, -(MESH_UNIT as f32 / 2.0)),
+                        nav_vec2(MESH_UNIT as f32 / 4.0, MESH_UNIT as f32 / 2.0),
+                        nav_vec2(-(MESH_UNIT as f32 / 4.0), MESH_UNIT as f32 / 2.0),
                     ]),
                     simplify: 0.001,
                     merge_steps: 2,
@@ -428,8 +428,7 @@ fn move_obstacles(mut query: Query<(&mut Transform, &Obstacle)>, time: Res<Time>
                 transform.rotate(Quat::from_rotation_y(time.delta_secs() / speed))
             }
             Obstacle::Sliding(center_x) => {
-                transform.translation.x =
-                    center_x + (time.elapsed_secs() as f32 * 4.0).sin() * 35.0;
+                transform.translation.x = center_x + (time.elapsed_secs() * 4.0).sin() * 35.0;
             }
         }
     }
@@ -443,7 +442,12 @@ fn display_path(navmeshes: Res<Assets<NavMesh>>, mut gizmos: Gizmos<PathGizmo>) 
         vec2(MESH_UNIT as f32 * 1.5, -(MESH_UNIT as f32) / 4.0),
         vec2(MESH_UNIT as f32 * 1.5, MESH_UNIT as f32 * 3.25),
     )] {
-        let Some(start) = navmesh.get().get_point_layer(points.0).get(0).cloned() else {
+        let Some(start) = navmesh
+            .get()
+            .get_point_layer(NavVec2::new(points.0.x, points.0.y))
+            .first()
+            .cloned()
+        else {
             continue;
         };
         let Some(path) = navmesh.path(points.0, points.1) else {
@@ -452,7 +456,7 @@ fn display_path(navmeshes: Res<Assets<NavMesh>>, mut gizmos: Gizmos<PathGizmo>) 
         let mut path = path
             .path_with_layers
             .iter()
-            .map(|(v, layer)| vec3(v.x, point_to_height(v.xy(), *layer), v.y))
+            .map(|(v, layer)| vec3(v.x, point_to_height(vec2(v.x, v.y), *layer), v.y))
             .collect::<Vec<_>>();
         path.insert(
             0,

--- a/examples/layers_basic.rs
+++ b/examples/layers_basic.rs
@@ -67,7 +67,7 @@ fn setup(
     commands.spawn((
         DirectionalLight {
             illuminance: 3000.0,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
@@ -83,10 +83,10 @@ fn setup(
             p.spawn((
                 NavMeshSettings {
                     fixed: Triangulation::from_outer_edges(&[
-                        vec2(0.0, 0.0),
-                        vec2(MESH_UNIT as f32, 0.0),
-                        vec2(MESH_UNIT as f32, MESH_UNIT as f32 * 2.0),
-                        vec2(0.0, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(0.0, 0.0),
+                        nav_vec2(MESH_UNIT as f32, 0.0),
+                        nav_vec2(MESH_UNIT as f32, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(0.0, MESH_UNIT as f32 * 2.0),
                     ]),
                     simplify: 0.001,
                     merge_steps: 3,
@@ -130,10 +130,10 @@ fn setup(
             p.spawn((
                 NavMeshSettings {
                     fixed: Triangulation::from_outer_edges(&[
-                        vec2(0.0, 0.0),
-                        vec2(MESH_UNIT as f32, 0.0),
-                        vec2(MESH_UNIT as f32, MESH_UNIT as f32 * 2.0),
-                        vec2(0.0, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(0.0, 0.0),
+                        nav_vec2(MESH_UNIT as f32, 0.0),
+                        nav_vec2(MESH_UNIT as f32, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(0.0, MESH_UNIT as f32 * 2.0),
                     ]),
                     simplify: 0.001,
                     merge_steps: 3,

--- a/examples/layers_inclined.rs
+++ b/examples/layers_inclined.rs
@@ -69,7 +69,7 @@ fn setup(
     commands.spawn((
         DirectionalLight {
             illuminance: 3000.0,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::default().looking_at(Vec3::new(-1.0, -2.5, -1.5), Vec3::Y),
@@ -85,10 +85,10 @@ fn setup(
             p.spawn((
                 NavMeshSettings {
                     fixed: Triangulation::from_outer_edges(&[
-                        vec2(0.0, 0.0),
-                        vec2(MESH_UNIT as f32, 0.0),
-                        vec2(MESH_UNIT as f32, MESH_UNIT as f32 * 2.0),
-                        vec2(0.0, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(0.0, 0.0),
+                        nav_vec2(MESH_UNIT as f32, 0.0),
+                        nav_vec2(MESH_UNIT as f32, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(0.0, MESH_UNIT as f32 * 2.0),
                     ]),
                     simplify: 0.001,
                     merge_steps: 3,
@@ -143,10 +143,10 @@ fn setup(
             p.spawn((
                 NavMeshSettings {
                     fixed: Triangulation::from_outer_edges(&[
-                        vec2(0.0, 0.0),
-                        vec2(MESH_UNIT as f32, 0.0),
-                        vec2(MESH_UNIT as f32, MESH_UNIT as f32 * 2.0),
-                        vec2(0.0, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(0.0, 0.0),
+                        nav_vec2(MESH_UNIT as f32, 0.0),
+                        nav_vec2(MESH_UNIT as f32, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(0.0, MESH_UNIT as f32 * 2.0),
                     ]),
                     simplify: 0.001,
                     merge_steps: 3,
@@ -204,10 +204,10 @@ fn setup(
             p.spawn((
                 NavMeshSettings {
                     fixed: Triangulation::from_outer_edges(&[
-                        vec2(0.0, 0.0),
-                        vec2(MESH_UNIT as f32, 0.0),
-                        vec2(MESH_UNIT as f32, MESH_UNIT as f32 * 2.0),
-                        vec2(0.0, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(0.0, 0.0),
+                        nav_vec2(MESH_UNIT as f32, 0.0),
+                        nav_vec2(MESH_UNIT as f32, MESH_UNIT as f32 * 2.0),
+                        nav_vec2(0.0, MESH_UNIT as f32 * 2.0),
                     ]),
                     simplify: 0.001,
                     merge_steps: 3,
@@ -384,7 +384,9 @@ fn display_path(
         let Some(path) = navmesh.transformed_path(points.0, points.1) else {
             continue;
         };
-        let start = navmesh.get().get_point_layer(points.0.xz())[0];
+        let start = navmesh
+            .get()
+            .get_point_layer(NavVec2::new(points.0.x, points.0.z))[0];
 
         let mut path = path
             .path_with_layers

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -4,7 +4,7 @@ use bevy::{
     sprite_render::ColorMaterial,
     window::{PrimaryWindow, WindowResized},
 };
-use vleue_navigator::{NavMesh, VleueNavigatorPlugin};
+use vleue_navigator::{NavMesh, NavVec2, VleueNavigatorPlugin};
 
 fn main() {
     App::new()
@@ -80,29 +80,29 @@ fn setup(
         simple: navmeshes.add(NavMesh::from_polyanya_mesh(
             polyanya::Mesh::new(
                 vec![
-                    polyanya::Vertex::new(Vec2::new(0., 6.), vec![0, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(2., 5.), vec![0, u32::MAX, 2]),
-                    polyanya::Vertex::new(Vec2::new(5., 7.), vec![0, 2, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(5., 8.), vec![0, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(0., 8.), vec![0, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(1., 4.), vec![1, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(2., 1.), vec![1, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(4., 1.), vec![1, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(4., 2.), vec![1, u32::MAX, 2]),
-                    polyanya::Vertex::new(Vec2::new(2., 4.), vec![1, 2, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(7., 4.), vec![2, u32::MAX, 4]),
-                    polyanya::Vertex::new(Vec2::new(10., 7.), vec![2, 4, 6, u32::MAX, 3]),
-                    polyanya::Vertex::new(Vec2::new(7., 7.), vec![2, 3, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(11., 8.), vec![3, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(7., 8.), vec![3, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(7., 0.), vec![5, 4, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(11., 3.), vec![4, 5, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(11., 5.), vec![4, u32::MAX, 6]),
-                    polyanya::Vertex::new(Vec2::new(12., 0.), vec![5, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(12., 3.), vec![5, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(13., 5.), vec![6, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(13., 7.), vec![6, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(1., 3.), vec![1, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(0., 6.), vec![0, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(2., 5.), vec![0, u32::MAX, 2]),
+                    polyanya::Vertex::new(NavVec2::new(5., 7.), vec![0, 2, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(5., 8.), vec![0, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(0., 8.), vec![0, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(1., 4.), vec![1, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(2., 1.), vec![1, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(4., 1.), vec![1, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(4., 2.), vec![1, u32::MAX, 2]),
+                    polyanya::Vertex::new(NavVec2::new(2., 4.), vec![1, 2, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(7., 4.), vec![2, u32::MAX, 4]),
+                    polyanya::Vertex::new(NavVec2::new(10., 7.), vec![2, 4, 6, u32::MAX, 3]),
+                    polyanya::Vertex::new(NavVec2::new(7., 7.), vec![2, 3, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(11., 8.), vec![3, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(7., 8.), vec![3, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(7., 0.), vec![5, 4, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(11., 3.), vec![4, 5, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(11., 5.), vec![4, u32::MAX, 6]),
+                    polyanya::Vertex::new(NavVec2::new(12., 0.), vec![5, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(12., 3.), vec![5, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(13., 5.), vec![6, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(13., 7.), vec![6, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(1., 3.), vec![1, u32::MAX]),
                 ],
                 vec![
                     polyanya::Polygon::new(vec![0, 1, 2, 3, 4], true),
@@ -127,6 +127,7 @@ struct PathToDisplay {
     steps: Vec<Vec2>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn on_mesh_change(
     mut path_to_display: ResMut<PathToDisplay>,
     mesh: Res<MeshDetails>,
@@ -161,7 +162,7 @@ fn on_mesh_change(
     *current_mesh_entity = Some(
         commands
             .spawn((
-                Mesh2d(meshes.add(navmesh.to_mesh()).into()),
+                Mesh2d(meshes.add(navmesh.to_mesh())),
                 Transform::from_translation(Vec3::new(
                     -mesh.size.x / 2.0 * factor,
                     -mesh.size.y / 2.0 * factor,
@@ -174,7 +175,7 @@ fn on_mesh_change(
             ))
             .with_children(|main_mesh| {
                 main_mesh.spawn((
-                    Mesh2d(meshes.add(navmesh.to_wireframe_mesh()).into()),
+                    Mesh2d(meshes.add(navmesh.to_wireframe_mesh())),
                     Transform::from_translation(Vec3::new(0.0, 0.0, 0.1)),
                     MeshMaterial2d(materials.add(ColorMaterial::from(Color::srgb(0.5, 0.5, 1.0)))),
                 ));
@@ -208,21 +209,21 @@ fn on_mesh_change(
                     .to_string(),
                 ),
                 TextFont {
-                    font_size: 25.0,
+                    font_size: 25.0.into(),
                     ..default()
                 },
             ));
             p.spawn((
                 TextSpan::new("Press spacebar to switch mesh\n".to_string()),
                 TextFont {
-                    font_size: 15.0,
+                    font_size: 15.0.into(),
                     ..default()
                 },
             ));
             p.spawn((
                 TextSpan::new("Click to find a path".to_string()),
                 TextFont {
-                    font_size: 15.0,
+                    font_size: 15.0.into(),
                     ..default()
                 },
             ));
@@ -305,7 +306,7 @@ fn compute_paths(
             .unwrap();
         if let Some(path) = navmesh.path(*path_to_display.steps.last().unwrap(), ev.0) {
             for p in path.path {
-                path_to_display.steps.push(p);
+                path_to_display.steps.push(Vec2::new(p.x, p.y));
             }
         } else {
             info!("no path found");

--- a/examples/many.rs
+++ b/examples/many.rs
@@ -117,7 +117,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 p.spawn((
                     TextSpan::new(text.to_string()),
                     TextFont {
-                        font_size,
+                        font_size: font_size.into(),
                         ..default()
                     },
                 ));
@@ -125,6 +125,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         });
 }
 
+#[allow(clippy::too_many_arguments)]
 fn on_mesh_change(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -148,7 +149,7 @@ fn on_mesh_change(
             *current_mesh_entity = Some(
                 commands
                     .spawn((
-                        Mesh2d(meshes.add(navmesh.to_mesh()).into()),
+                        Mesh2d(meshes.add(navmesh.to_mesh())),
                         Transform::from_translation(Vec3::new(
                             -MESH_SIZE.x / 2.0 * factor,
                             -MESH_SIZE.y / 2.0 * factor,
@@ -312,7 +313,9 @@ fn poll_path_tasks(
             if let Some(path) = task.path.take() {
                 commands
                     .entity(entity)
-                    .insert(Path { path: path.path })
+                    .insert(Path {
+                        path: path.path.into_iter().map(|p| Vec2::new(p.x, p.y)).collect(),
+                    })
                     .remove::<FindingPath>();
             } else {
                 let window = *primary_window;
@@ -364,6 +367,7 @@ fn move_navigator(
         });
 }
 
+#[allow(clippy::type_complexity)]
 fn go_somewhere(
     query: Query<
         Entity,
@@ -386,6 +390,7 @@ fn go_somewhere(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn update_ui(
     ui_query: Query<Entity, With<Text>>,
     mut text_writer: TextUiWriter,
@@ -440,10 +445,10 @@ fn self_regulate(
     not_moving: Query<(Entity, Ref<GlobalTransform>), With<Navigator>>,
 ) {
     for (entity, transform) in &not_moving {
-        if !transform.is_changed() {
-            if system.this_run().get() - transform.last_changed().get() > 100000 {
-                commands.entity(entity).despawn();
-            }
+        if !transform.is_changed()
+            && system.this_run().get() - transform.last_changed().get() > 100000
+        {
+            commands.entity(entity).despawn();
         }
     }
 }

--- a/examples/moving.rs
+++ b/examples/moving.rs
@@ -12,7 +12,7 @@ use bevy::{
     window::{PrimaryWindow, WindowResized},
 };
 
-use vleue_navigator::{NavMesh, VleueNavigatorPlugin};
+use vleue_navigator::{NavMesh, NavVec2, VleueNavigatorPlugin};
 
 fn main() {
     App::new()
@@ -88,29 +88,29 @@ fn setup(
         simple: navmeshes.add(NavMesh::from_polyanya_mesh(
             polyanya::Mesh::new(
                 vec![
-                    polyanya::Vertex::new(Vec2::new(0., 6.), vec![0, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(2., 5.), vec![0, u32::MAX, 2]),
-                    polyanya::Vertex::new(Vec2::new(5., 7.), vec![0, 2, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(5., 8.), vec![0, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(0., 8.), vec![0, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(1., 4.), vec![1, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(2., 1.), vec![1, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(4., 1.), vec![1, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(4., 2.), vec![1, u32::MAX, 2]),
-                    polyanya::Vertex::new(Vec2::new(2., 4.), vec![1, 2, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(7., 4.), vec![2, u32::MAX, 4]),
-                    polyanya::Vertex::new(Vec2::new(10., 7.), vec![2, 4, 6, u32::MAX, 3]),
-                    polyanya::Vertex::new(Vec2::new(7., 7.), vec![2, 3, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(11., 8.), vec![3, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(7., 8.), vec![3, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(7., 0.), vec![5, 4, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(11., 3.), vec![4, 5, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(11., 5.), vec![4, u32::MAX, 6]),
-                    polyanya::Vertex::new(Vec2::new(12., 0.), vec![5, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(12., 3.), vec![5, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(13., 5.), vec![6, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(13., 7.), vec![6, u32::MAX]),
-                    polyanya::Vertex::new(Vec2::new(1., 3.), vec![1, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(0., 6.), vec![0, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(2., 5.), vec![0, u32::MAX, 2]),
+                    polyanya::Vertex::new(NavVec2::new(5., 7.), vec![0, 2, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(5., 8.), vec![0, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(0., 8.), vec![0, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(1., 4.), vec![1, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(2., 1.), vec![1, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(4., 1.), vec![1, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(4., 2.), vec![1, u32::MAX, 2]),
+                    polyanya::Vertex::new(NavVec2::new(2., 4.), vec![1, 2, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(7., 4.), vec![2, u32::MAX, 4]),
+                    polyanya::Vertex::new(NavVec2::new(10., 7.), vec![2, 4, 6, u32::MAX, 3]),
+                    polyanya::Vertex::new(NavVec2::new(7., 7.), vec![2, 3, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(11., 8.), vec![3, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(7., 8.), vec![3, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(7., 0.), vec![5, 4, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(11., 3.), vec![4, 5, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(11., 5.), vec![4, u32::MAX, 6]),
+                    polyanya::Vertex::new(NavVec2::new(12., 0.), vec![5, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(12., 3.), vec![5, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(13., 5.), vec![6, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(13., 7.), vec![6, u32::MAX]),
+                    polyanya::Vertex::new(NavVec2::new(1., 3.), vec![1, u32::MAX]),
                 ],
                 vec![
                     polyanya::Polygon::new(vec![0, 1, 2, 3, 4], true),
@@ -130,6 +130,7 @@ fn setup(
     commands.insert_resource(AURORA);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn on_mesh_change(
     mesh: Res<MeshDetails>,
     mut commands: Commands,
@@ -163,7 +164,7 @@ fn on_mesh_change(
             *current_mesh_entity = Some(
                 commands
                     .spawn((
-                        Mesh2d(meshes.add(navmesh.to_mesh()).into()),
+                        Mesh2d(meshes.add(navmesh.to_mesh())),
                         Transform::from_translation(Vec3::new(
                             -mesh.size.x / 2.0 * factor,
                             -mesh.size.y / 2.0 * factor,
@@ -204,21 +205,21 @@ fn on_mesh_change(
                             .to_string(),
                         ),
                         TextFont {
-                            font_size: 25.0,
+                            font_size: 25.0.into(),
                             ..default()
                         },
                     ));
                     p.spawn((
                         TextSpan::new("Press spacebar to switch mesh\n".to_string()),
                         TextFont {
-                            font_size: 15.0,
+                            font_size: 15.0.into(),
                             ..default()
                         },
                     ));
                     p.spawn((
                         TextSpan::new("Click to find a path".to_string()),
                         TextFont {
-                            font_size: 15.0,
+                            font_size: 15.0.into(),
                             ..default()
                         },
                     ));
@@ -243,11 +244,11 @@ fn mesh_change(
     if mouse_input.just_released(MouseButton::Left) {
         *pressed_since = None;
     }
-    if let Some(started) = *pressed_since {
-        if (time.elapsed() - started).as_secs() > 1 {
-            touch_triggered = true;
-            *pressed_since = None;
-        }
+    if let Some(started) = *pressed_since
+        && (time.elapsed() - started).as_secs() > 1
+    {
+        touch_triggered = true;
+        *pressed_since = None;
     }
     if keyboard_input.just_pressed(KeyCode::Space) || touch_triggered {
         match mesh.mesh {
@@ -274,6 +275,7 @@ struct Path {
     path: Vec<Vec2>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn on_click(
     mouse_button_input: Res<ButtonInput<MouseButton>>,
     primary_window: Single<&Window, With<PrimaryWindow>>,
@@ -375,7 +377,9 @@ fn poll_path_tasks(mut commands: Commands, computing: Query<(Entity, &FindingPat
             if let Some(path) = task.0.take() {
                 commands
                     .entity(entity)
-                    .insert(Path { path: path.path })
+                    .insert(Path {
+                        path: path.path.into_iter().map(|p| Vec2::new(p.x, p.y)).collect(),
+                    })
                     .remove::<FindingPath>();
             } else {
                 info!("no path found");

--- a/examples/primitive_3d.rs
+++ b/examples/primitive_3d.rs
@@ -83,7 +83,7 @@ fn setup(
     for (x, y) in [(0.25, 0.25), (0.75, 0.25), (0.25, 0.75), (0.75, 0.75)] {
         commands.spawn((
             PointLight {
-                shadows_enabled: true,
+                shadow_maps_enabled: true,
                 intensity: MESH_WIDTH.min(MESH_HEIGHT) as f32 * 300_000.0,
                 range: MESH_WIDTH.min(MESH_HEIGHT) as f32 * 10.0,
                 ..default()
@@ -101,10 +101,10 @@ fn setup(
         NavMeshSettings {
             // Define the outer borders of the navmesh.
             fixed: Triangulation::from_outer_edges(&[
-                vec2(0.0, 0.0),
-                vec2(MESH_WIDTH as f32, 0.0),
-                vec2(MESH_WIDTH as f32, MESH_HEIGHT as f32),
-                vec2(0.0, MESH_HEIGHT as f32),
+                nav_vec2(0.0, 0.0),
+                nav_vec2(MESH_WIDTH as f32, 0.0),
+                nav_vec2(MESH_WIDTH as f32, MESH_HEIGHT as f32),
+                nav_vec2(0.0, MESH_HEIGHT as f32),
             ]),
             simplify: 0.05,
             merge_steps: 0,

--- a/examples/random_obstacles.rs
+++ b/examples/random_obstacles.rs
@@ -54,6 +54,7 @@ struct PathToDisplay {
     steps: Vec<Vec2>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn on_mesh_change(
     mut path_to_display: ResMut<PathToDisplay>,
     mut commands: Commands,
@@ -85,7 +86,7 @@ fn on_mesh_change(
     *current_mesh_entity = Some(
         commands
             .spawn((
-                Mesh2d(meshes.add(navmesh.to_mesh()).into()),
+                Mesh2d(meshes.add(navmesh.to_mesh())),
                 Transform::from_translation(Vec3::new(
                     -MESH_WIDTH / 2.0 * factor,
                     -MESH_HEIGHT / 2.0 * factor,
@@ -98,7 +99,7 @@ fn on_mesh_change(
             ))
             .with_children(|main_mesh| {
                 main_mesh.spawn((
-                    Mesh2d(meshes.add(navmesh.to_wireframe_mesh()).into()),
+                    Mesh2d(meshes.add(navmesh.to_wireframe_mesh())),
                     Transform::from_translation(Vec3::new(0.0, 0.0, 0.1)),
                     MeshMaterial2d(materials.add(ColorMaterial::from(Color::srgb(0.5, 0.5, 1.0)))),
                 ));
@@ -125,21 +126,21 @@ fn on_mesh_change(
             p.spawn((
                 TextSpan::new("Random Triangle Obstacles\n".to_string()),
                 TextFont {
-                    font_size: 30.0,
+                    font_size: 30.0.into(),
                     ..default()
                 },
             ));
             p.spawn((
                 TextSpan::new("Press spacebar to change obstacles\n".to_string()),
                 TextFont {
-                    font_size: 25.0,
+                    font_size: 25.0.into(),
                     ..default()
                 },
             ));
             p.spawn((
                 TextSpan::new("Click to find a path".to_string()),
                 TextFont {
-                    font_size: 25.0,
+                    font_size: 25.0.into(),
                     ..default()
                 },
             ));
@@ -236,7 +237,7 @@ fn compute_paths(
         let navmesh = navmeshes.get(&meshes.0).unwrap();
         if let Some(path) = navmesh.path(*path_to_display.steps.last().unwrap(), ev.0) {
             for p in path.path {
-                path_to_display.steps.push(p);
+                path_to_display.steps.push(Vec2::new(p.x, p.y));
             }
         } else {
             info!("no path found");

--- a/examples/recast.rs
+++ b/examples/recast.rs
@@ -1,11 +1,11 @@
 use std::{f32::consts::FRAC_PI_2, fs::File};
 
 use bevy::{
+    camera::Hdr,
     color::palettes::{self},
     core_pipeline::tonemapping::Tonemapping,
     post_process::bloom::Bloom,
     prelude::*,
-    render::view::Hdr,
 };
 use vleue_navigator::{VleueNavigatorPlugin, display_layer_gizmo, prelude::*};
 
@@ -94,6 +94,18 @@ struct RecastNavmesh(polyanya::Mesh);
 #[derive(Resource)]
 struct Layers(Vec<bool>);
 
+fn to_polyanya_vec2(v: Vec2) -> NavVec2 {
+    NavVec2::new(v.x, v.y)
+}
+
+fn to_polyanya_vec3(v: Vec3) -> NavVec3 {
+    NavVec3::new(v.x, v.y, v.z)
+}
+
+fn to_bevy_vec3(v: NavVec3) -> Vec3 {
+    Vec3::new(v.x, v.y, v.z)
+}
+
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Camera3d::default(),
@@ -105,14 +117,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         Bloom::NATURAL,
     ));
 
-    commands.spawn(SceneRoot(
+    commands.spawn(WorldAssetRoot(
         asset_server.load(GltfAssetLabel::Scene(0).from_asset("recast/dungeon.glb")),
     ));
 
     commands.spawn((
         DirectionalLight {
             illuminance: light_consts::lux::OVERCAST_DAY,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(1.0, 1.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
@@ -125,12 +137,8 @@ fn draw_navmesh(
     layers: Res<Layers>,
 ) {
     let mesh = &recast.0;
-    let colors: Vec<Color> = LAYER_COLORS
-        .iter()
-        .map(|color| color.clone().into())
-        .collect();
-    for (layer, (color, enabled)) in mesh.layers.iter().zip(colors.iter().zip(layers.0.iter())) {
-        let mut color = *color;
+    for (layer, (color, enabled)) in mesh.layers.iter().zip(LAYER_COLORS.iter().zip(&layers.0)) {
+        let mut color: Color = (*color).into();
         if !enabled {
             color.set_alpha(0.2);
         }
@@ -143,6 +151,7 @@ fn draw_navmesh(
     }
 }
 
+#[allow(clippy::excessive_precision)]
 fn draw_path(
     mut path_gizmos: Gizmos<PathGizmos>,
     mut gizmos: Gizmos,
@@ -157,8 +166,8 @@ fn draw_path(
 
     let mesh = &recast.0;
     let Some(path) = mesh.path_on_layers(
-        start.xz(),
-        end.xz(),
+        to_polyanya_vec2(start.xz()),
+        to_polyanya_vec2(end.xz()),
         layers
             .0
             .iter()
@@ -169,7 +178,11 @@ fn draw_path(
         return;
     };
 
-    let mut path_with_height = path.path_with_height(start, end, mesh);
+    let mut path_with_height = path
+        .path_with_height(to_polyanya_vec3(start), to_polyanya_vec3(end), mesh)
+        .into_iter()
+        .map(to_bevy_vec3)
+        .collect::<Vec<_>>();
 
     for point in &path_with_height {
         path_gizmos.sphere(*point, 0.1, palettes::tailwind::BLUE_600);
@@ -193,11 +206,11 @@ fn layers_info(mut commands: Commands, layers: Res<Layers>, texts: Query<Entity,
         ))
         .with_children(|p| {
             let font_size = TextFont {
-                font_size: 15.0,
+                font_size: 15.0.into(),
                 ..default()
             };
             for layer in layers.0.iter().enumerate() {
-                let color = LAYER_COLORS[layer.0].clone().into();
+                let color = LAYER_COLORS[layer.0].into();
                 p.spawn((
                     TextSpan::new(format!("Layer {}: ", layer.0)),
                     TextColor(color),
@@ -233,14 +246,15 @@ fn switch_layers(mut layers: ResMut<Layers>, input: Res<ButtonInput<KeyCode>>) {
     .iter()
     .enumerate()
     {
-        if input.just_pressed(*key) {
-            if let Some(layer) = layers.0.get_mut(index) {
-                *layer = !*layer;
-            }
+        if input.just_pressed(*key)
+            && let Some(layer) = layers.0.get_mut(index)
+        {
+            *layer = !*layer;
         }
     }
 }
 
+#[allow(clippy::too_many_arguments, clippy::excessive_precision)]
 fn autonomous_demo(
     mut camera_transform: Single<&mut Transform, (Without<Agent>, With<Camera>)>,
     input: Res<ButtonInput<KeyCode>>,
@@ -383,14 +397,17 @@ fn autonomous_demo(
         .filter_map(|(n, e)| (!e).then_some(n as u8))
         .collect();
     for (entity, mut transform, material) in &mut agents {
-        let Some(path) = mesh.path_on_layers(transform.translation.xz(), end.xz(), layers.clone())
-        else {
+        let Some(path) = mesh.path_on_layers(
+            to_polyanya_vec2(transform.translation.xz()),
+            to_polyanya_vec2(end.xz()),
+            layers.clone(),
+        ) else {
             continue;
         };
         if *bloomed {
             let next_polygon_in_path = path.polygons().first().unwrap().0;
             let material = materials.get_mut(material.id());
-            let material = material.unwrap();
+            let mut material = material.unwrap();
             if next_polygon_in_path == 2 {
                 material.emissive = Srgba::new(0.6, 10.0, 0.2, 1.0).into();
             } else {
@@ -400,9 +417,14 @@ fn autonomous_demo(
                 material.base_color = LAYER_COLORS[next_polygon_in_path as usize].into();
             }
         }
-        let move_dir = (path.path_with_height(transform.translation, end, mesh)[0]
-            - transform.translation)
-            .normalize();
+        let next = to_bevy_vec3(
+            path.path_with_height(
+                to_polyanya_vec3(transform.translation),
+                to_polyanya_vec3(end),
+                mesh,
+            )[0],
+        );
+        let move_dir = (next - transform.translation).normalize();
         transform.translation += move_dir / 10.0;
         if *finished {
             transform.translation += move_dir / 15.0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,14 +45,14 @@ pub mod prelude {
         CachableObstacle, ManagedNavMesh, NAVMESH_BUILD_DURATION, NavMeshSettings, NavMeshStatus,
         NavMeshUpdateMode, NavMeshUpdateModeBlocking, NavmeshUpdaterPlugin,
     };
-    pub use crate::{NavMesh, Triangulation, VleueNavigatorPlugin};
+    pub use crate::{NavMesh, NavVec2, NavVec3, Triangulation, VleueNavigatorPlugin, nav_vec2};
     #[cfg(feature = "debug-with-gizmos")]
     pub use crate::{NavMeshDebug, NavMeshesDebug};
 }
 
 /// Bevy plugin to add support for the [`NavMesh`] asset type.
 ///
-/// This plugin doesn't add support for updating them. See [`NavmeshUpdaterPlugin`] for that.
+/// This plugin doesn't add support for updating them. See [`NavmeshUpdaterPlugin`](crate::updater::NavmeshUpdaterPlugin) for that.
 #[derive(Debug, Clone, Copy)]
 pub struct VleueNavigatorPlugin;
 
@@ -103,6 +103,17 @@ pub struct TransformedPath {
 use polyanya::Trimesh;
 pub use polyanya::{Path, Triangulation};
 
+/// Coordinate types used by Polyanya inputs and paths.
+pub use polyanya_glam::{Vec2 as NavVec2, Vec3 as NavVec3, vec2 as nav_vec2};
+
+pub(crate) fn to_polyanya_vec2(v: Vec2) -> NavVec2 {
+    NavVec2::new(v.x, v.y)
+}
+
+pub(crate) fn to_bevy_vec3(v: NavVec3) -> Vec3 {
+    Vec3::new(v.x, v.y, v.z)
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct BuildingMesh {
     pub(crate) mesh: polyanya::Mesh,
@@ -148,7 +159,7 @@ impl NavMesh {
         let vertices = get_vectors(mesh, Mesh::ATTRIBUTE_POSITION)
             .expect("can't extract a navmesh from a mesh without `Mesh::ATTRIBUTE_POSITION`")
             .map(|vertex| rotation_reverse.mul_vec3(vertex))
-            .map(|coords| coords.xy())
+            .map(|coords| to_polyanya_vec2(coords.xy()))
             .collect();
 
         let triangles = mesh
@@ -188,6 +199,13 @@ impl NavMesh {
     ///
     /// Depending on the scale of your mesh, you should change the [`Self::search_delta`] value using [`Self::set_search_delta`].
     pub fn from_edge_and_obstacles(edges: Vec<Vec2>, obstacles: Vec<Vec<Vec2>>) -> NavMesh {
+        let edges = edges.into_iter().map(to_polyanya_vec2).collect::<Vec<_>>();
+        let obstacles = obstacles.into_iter().map(|obstacle| {
+            obstacle
+                .into_iter()
+                .map(to_polyanya_vec2)
+                .collect::<Vec<_>>()
+        });
         let mut triangulation = Triangulation::from_outer_edges(&edges);
         triangulation.add_obstacles(obstacles);
 
@@ -249,7 +267,9 @@ impl NavMesh {
     /// Asynchronously finds the shortest path between two points.
     #[inline]
     pub async fn get_path(&self, from: Vec2, to: Vec2) -> Option<Path> {
-        self.mesh.get_path(from, to).await
+        self.mesh
+            .get_path(to_polyanya_vec2(from), to_polyanya_vec2(to))
+            .await
     }
 
     /// Asynchronously finds the shortest path between two points.
@@ -258,14 +278,17 @@ impl NavMesh {
     pub async fn get_transformed_path(&self, from: Vec3, to: Vec3) -> Option<TransformedPath> {
         let inner_from = self.world_to_mesh().transform_point(from).xy();
         let inner_to = self.world_to_mesh().transform_point(to).xy();
-        let path = self.mesh.get_path(inner_from, inner_to).await;
+        let path = self
+            .mesh
+            .get_path(to_polyanya_vec2(inner_from), to_polyanya_vec2(inner_to))
+            .await;
         path.map(|path| self.transform_path(path))
     }
 
     /// Finds the shortest path between two points.
     #[inline]
     pub fn path(&self, from: Vec2, to: Vec2) -> Option<Path> {
-        self.mesh.path(from, to)
+        self.mesh.path(to_polyanya_vec2(from), to_polyanya_vec2(to))
     }
 
     /// Finds the shortest path between two points.
@@ -274,7 +297,9 @@ impl NavMesh {
     pub fn transformed_path(&self, from: Vec3, to: Vec3) -> Option<TransformedPath> {
         let inner_from = self.world_to_mesh().transform_point(from).xy();
         let inner_to = self.world_to_mesh().transform_point(to).xy();
-        let path = self.mesh.path(inner_from, inner_to);
+        let path = self
+            .mesh
+            .path(to_polyanya_vec2(inner_from), to_polyanya_vec2(inner_to));
         path.map(|path| self.transform_path(path))
     }
 
@@ -286,13 +311,18 @@ impl NavMesh {
             path: path
                 .path
                 .into_iter()
-                .map(|coords| transform.transform_point(coords.extend(0.0)))
+                .map(|coords| transform.transform_point(to_bevy_vec3(coords.extend(0.0))))
                 .collect(),
             #[cfg(feature = "detailed-layers")]
             path_with_layers: path
                 .path_with_layers
                 .into_iter()
-                .map(|(coords, layer)| (transform.transform_point(coords.extend(0.0)), layer))
+                .map(|(coords, layer)| {
+                    (
+                        transform.transform_point(to_bevy_vec3(coords.extend(0.0))),
+                        layer,
+                    )
+                })
                 .collect(),
         }
     }
@@ -300,12 +330,12 @@ impl NavMesh {
     /// Checks if a 3D point is within a navigable part of the mesh, using the [`NavMesh::transform`].
     pub fn transformed_is_in_mesh(&self, point: Vec3) -> bool {
         let point_in_navmesh = self.world_to_mesh().transform_point(point).xy();
-        self.mesh.point_in_mesh(point_in_navmesh)
+        self.mesh.point_in_mesh(to_polyanya_vec2(point_in_navmesh))
     }
 
     /// Checks if a point is within a navigable part of the mesh.
     pub fn is_in_mesh(&self, point: Vec2) -> bool {
-        self.mesh.point_in_mesh(point)
+        self.mesh.point_in_mesh(to_polyanya_vec2(point))
     }
 
     /// Retrieves the transform used to convert world coordinates into mesh coordinates.
@@ -333,7 +363,7 @@ impl NavMesh {
             self.mesh.layers[0]
                 .vertices
                 .iter()
-                .map(|v| v.coords.extend(0.0))
+                .map(|v| to_bevy_vec3(v.coords.extend(0.0)))
                 .map(|coords| mesh_to_world.transform_point(coords).into())
                 .collect::<Vec<[f32; 3]>>(),
         );
@@ -445,6 +475,14 @@ pub fn display_mesh_gizmo<T: bevy::gizmos::config::GizmoConfigGroup>(
 }
 
 #[cfg(feature = "debug-with-gizmos")]
+fn layer_vertex_position(layer: &polyanya::Layer, scale: NavVec2, index: usize) -> Vec3 {
+    to_bevy_vec3(
+        (layer.vertices[index].coords * scale)
+            .extend(-layer.height.get(index).cloned().unwrap_or_default()),
+    )
+}
+
+#[cfg(feature = "debug-with-gizmos")]
 /// Display a layer with gizmos.
 pub fn display_layer_gizmo<T: bevy::gizmos::config::GizmoConfigGroup>(
     layer: &polyanya::Layer,
@@ -455,27 +493,18 @@ pub fn display_layer_gizmo<T: bevy::gizmos::config::GizmoConfigGroup>(
     #[cfg(feature = "detailed-layers")]
     let scale = layer.scale;
     #[cfg(not(feature = "detailed-layers"))]
-    let scale = Vec2::ONE;
+    let scale = NavVec2::ONE;
     for polygon in &layer.polygons {
         let mut v = polygon
             .vertices
             .iter()
             .filter(|i| **i != u32::MAX)
-            .map(|i| {
-                (layer.vertices[*i as usize].coords * scale)
-                    .extend(-layer.height.get(*i as usize).cloned().unwrap_or_default())
-            })
+            .map(|i| layer_vertex_position(layer, scale, *i as usize))
             .map(|v| mesh_to_world.transform_point(v))
             .collect::<Vec<_>>();
         if !v.is_empty() {
             let first_index = polygon.vertices[0] as usize;
-            let first = &layer.vertices[first_index];
-            v.push(
-                mesh_to_world.transform_point(
-                    (first.coords * scale)
-                        .extend(-layer.height.get(first_index).cloned().unwrap_or_default()),
-                ),
-            );
+            v.push(mesh_to_world.transform_point(layer_vertex_position(layer, scale, first_index)));
             gizmos.linestrip(v, color);
         }
     }
@@ -493,27 +522,18 @@ pub fn display_polygon_gizmo<T: bevy::gizmos::config::GizmoConfigGroup>(
     #[cfg(feature = "detailed-layers")]
     let scale = layer.scale;
     #[cfg(not(feature = "detailed-layers"))]
-    let scale = Vec2::ONE;
+    let scale = NavVec2::ONE;
     let polygon = &layer.polygons[polygon as usize];
     let mut v = polygon
         .vertices
         .iter()
         .filter(|i| **i != u32::MAX)
-        .map(|i| {
-            (layer.vertices[*i as usize].coords * scale)
-                .extend(-layer.height.get(*i as usize).cloned().unwrap_or_default())
-        })
+        .map(|i| layer_vertex_position(layer, scale, *i as usize))
         .map(|v| mesh_to_world.transform_point(v))
         .collect::<Vec<_>>();
     if !v.is_empty() {
         let first_index = polygon.vertices[0] as usize;
-        let first = &layer.vertices[first_index];
-        v.push(
-            mesh_to_world.transform_point(
-                (first.coords * scale)
-                    .extend(-layer.height.get(first_index).cloned().unwrap_or_default()),
-            ),
-        );
+        v.push(mesh_to_world.transform_point(layer_vertex_position(layer, scale, first_index)));
         gizmos.linestrip(v, color);
     }
 }
@@ -530,12 +550,12 @@ mod tests {
         let expected_navmesh = NavMesh::from_polyanya_mesh(
             Trimesh {
                 vertices: vec![
-                    Vec2::new(1., 1.),
-                    Vec2::new(5., 1.),
-                    Vec2::new(5., 4.),
-                    Vec2::new(1., 4.),
-                    Vec2::new(2., 2.),
-                    Vec2::new(4., 3.),
+                    NavVec2::new(1., 1.),
+                    NavVec2::new(5., 1.),
+                    NavVec2::new(5., 4.),
+                    NavVec2::new(1., 4.),
+                    NavVec2::new(2., 2.),
+                    NavVec2::new(4., 3.),
                 ],
                 triangles: vec![[4, 1, 0], [5, 2, 1], [3, 2, 5], [3, 5, 1], [3, 4, 0]],
             }
@@ -545,12 +565,12 @@ mod tests {
         let initial_navmesh = NavMesh::from_polyanya_mesh(
             Trimesh {
                 vertices: vec![
-                    Vec2::new(1., 1.),
-                    Vec2::new(5., 1.),
-                    Vec2::new(5., 4.),
-                    Vec2::new(1., 4.),
-                    Vec2::new(2., 2.),
-                    Vec2::new(4., 3.),
+                    NavVec2::new(1., 1.),
+                    NavVec2::new(5., 1.),
+                    NavVec2::new(5., 4.),
+                    NavVec2::new(1., 4.),
+                    NavVec2::new(2., 2.),
+                    NavVec2::new(4., 3.),
                 ],
                 triangles: vec![[0, 1, 4], [1, 2, 5], [5, 2, 3], [1, 5, 3], [0, 4, 3]],
             }
@@ -573,10 +593,10 @@ mod tests {
         let expected_navmesh = NavMesh::from_polyanya_mesh(
             Trimesh {
                 vertices: vec![
-                    Vec2::new(-1., 1.),
-                    Vec2::new(1., 1.),
-                    Vec2::new(-1., -1.),
-                    Vec2::new(1., -1.),
+                    NavVec2::new(-1., 1.),
+                    NavVec2::new(1., 1.),
+                    NavVec2::new(-1., -1.),
+                    NavVec2::new(1., -1.),
                 ],
                 triangles: vec![[3, 1, 0], [2, 3, 0]],
             }

--- a/src/obstacles/avian2d.rs
+++ b/src/obstacles/avian2d.rs
@@ -1,8 +1,5 @@
 use avian2d::{
-    parry::{
-        na::{Const, OPoint},
-        shape::TypedShape,
-    },
+    parry::{math::Vector, shape::TypedShape},
     prelude::{Collider, Sleeping},
 };
 use bevy::{
@@ -49,7 +46,7 @@ impl InnerObstacleSource for TypedShape<'_> {
         transform.scale = Vec3::ONE;
         let world_to_mesh = world_to_mesh(navmesh_transform);
 
-        let ref_to_world = |p: &OPoint<f32, Const<2>>| {
+        let ref_to_world = |p: &Vector| {
             let mut v = vec3(p.x, 0.0, p.y);
             v = if up.is_negative_bitmask().count_ones() % 2 == 1 {
                 Quat::from_rotation_arc(Vec3::Y, up.into()).mul_vec3(v)
@@ -58,7 +55,7 @@ impl InnerObstacleSource for TypedShape<'_> {
             };
             transform.transform_point(v)
         };
-        let to_world = |p: OPoint<f32, Const<2>>| ref_to_world(&p);
+        let to_world = |p: Vector| ref_to_world(&p);
 
         let to_navmesh = |v: Vec3| world_to_mesh.transform_point3(v).xy();
 

--- a/src/obstacles/avian3d.rs
+++ b/src/obstacles/avian3d.rs
@@ -1,7 +1,7 @@
 use avian3d::{
     dynamics::rigid_body::sleeping::Sleeping,
     parry::{
-        na::{Const, OPoint, Unit, Vector3},
+        math::Vector as ParryVector,
         query::IntersectResult,
         shape::{Polyline, TriMesh, TypedShape},
     },
@@ -46,8 +46,7 @@ impl InnerObstacleSource for TypedShape<'_> {
         transform.scale = Vec3::ONE;
         let world_to_mesh = world_to_mesh(navmesh_transform);
 
-        let to_navmesh =
-            |p: OPoint<f32, Const<3>>| world_to_mesh.transform_point(vec3(p.x, p.y, p.z)).xy();
+        let to_navmesh = |p: ParryVector| world_to_mesh.transform_point(vec3(p.x, p.y, p.z)).xy();
 
         let intersection_to_navmesh = |intersection: IntersectResult<Polyline>| match intersection {
             IntersectResult::Intersect(i) => i
@@ -65,48 +64,48 @@ impl InnerObstacleSource for TypedShape<'_> {
             / (up.x.powi(2) + up.y.powi(2) + up.z.powi(2)).sqrt();
         let shift: f32 = shift - d;
 
-        let to_world = |p: &OPoint<f32, Const<3>>| transform.transform_point(vec3(p.x, p.y, p.z));
+        let to_world = |p: &ParryVector| transform.transform_point(vec3(p.x, p.y, p.z));
 
-        let up_axis = Unit::new_normalize(Vector3::new(up.x, up.y, up.z));
-        let trimesh_to_world = |vertices: Vec<OPoint<f32, Const<3>>>| {
+        let up_axis = ParryVector::new(up.x, up.y, up.z).normalize();
+        let trimesh_to_world = |vertices: Vec<ParryVector>| {
             vertices
                 .iter()
                 .map(to_world)
-                .map(|v| v.into())
-                .collect::<Vec<OPoint<f32, Const<3>>>>()
+                .map(|v| ParryVector::new(v.x, v.y, v.z))
+                .collect::<Vec<ParryVector>>()
         };
         match self {
             TypedShape::Cuboid(collider) => {
                 let (vertices, indices) = collider.to_trimesh();
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices).unwrap();
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::Ball(collider) => {
                 let (vertices, indices) = collider.to_trimesh(RESOLUTION, RESOLUTION);
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices).unwrap();
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::Capsule(collider) => {
                 let (vertices, indices) = collider.to_trimesh(RESOLUTION, RESOLUTION);
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices).unwrap();
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::TriMesh(collider) => {
                 vec![intersection_to_navmesh(
-                    collider.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    collider.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::HeightField(collider) => {
                 let (vertices, indices) = collider.to_trimesh();
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices).unwrap();
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::Compound(collider) => {
@@ -128,7 +127,7 @@ impl InnerObstacleSource for TypedShape<'_> {
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices)
                     .expect("Failed to create TriMesh");
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::Cylinder(collider) => {
@@ -136,7 +135,7 @@ impl InnerObstacleSource for TypedShape<'_> {
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices)
                     .expect("Failed to create TriMesh");
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::Cone(collider) => {
@@ -144,7 +143,7 @@ impl InnerObstacleSource for TypedShape<'_> {
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices)
                     .expect("Failed to create TriMesh");
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::RoundCuboid(collider) => {
@@ -152,7 +151,7 @@ impl InnerObstacleSource for TypedShape<'_> {
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices)
                     .expect("Failed to create TriMesh");
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::RoundCylinder(collider) => {
@@ -160,7 +159,7 @@ impl InnerObstacleSource for TypedShape<'_> {
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices)
                     .expect("Failed to create TriMesh");
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::RoundCone(collider) => {
@@ -168,7 +167,7 @@ impl InnerObstacleSource for TypedShape<'_> {
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices)
                     .expect("Failed to create TriMesh");
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::RoundConvexPolyhedron(collider) => {
@@ -176,7 +175,7 @@ impl InnerObstacleSource for TypedShape<'_> {
                 let trimesh = TriMesh::new(trimesh_to_world(vertices), indices)
                     .expect("Failed to create TriMesh");
                 vec![intersection_to_navmesh(
-                    trimesh.intersection_with_local_plane(&up_axis, shift, f32::EPSILON),
+                    trimesh.intersection_with_local_plane(up_axis, shift, f32::EPSILON),
                 )]
             }
             TypedShape::Segment(_) => {

--- a/src/obstacles/primitive.rs
+++ b/src/obstacles/primitive.rs
@@ -11,7 +11,7 @@ use crate::world_to_mesh;
 
 use super::{ObstacleSource, RESOLUTION};
 
-/// A primitive obstacle that can be used to create a [`NavMesh`].
+/// A primitive obstacle that can be used to create a [`NavMesh`](crate::NavMesh).
 /// Variants are made from primitive shapes defined in Bevy
 #[derive(Component, Debug, Clone)]
 pub enum PrimitiveObstacle {

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -18,7 +18,7 @@ use bevy::{
 };
 use polyanya::{Layer, Mesh, Triangulation};
 
-use crate::{NavMesh, obstacles::ObstacleSource};
+use crate::{NavMesh, obstacles::ObstacleSource, to_polyanya_vec2};
 
 /// A Marker component for an obstacle that can be cached.
 ///
@@ -192,7 +192,7 @@ impl Default for NavMeshUpdateMode {
     }
 }
 
-/// If this component is added to an entity with the [`NavMeshBundle`], updating the [`NavMesh`] will be blocking.
+/// If this component is added to an entity with [`NavMeshSettings`], updating the [`NavMesh`] will be blocking.
 /// Otherwise, it will be done asynchronous and occur on the [`AsyncComputeTaskPool`].
 ///
 /// This can cause the game to lag if updating the [`NavMesh`] takes longer than a frame. This is not recommended to use.
@@ -208,7 +208,15 @@ fn build_navmesh<T: ObstacleSource>(
 ) -> (Option<Triangulation>, Layer) {
     let up = (mesh_transform.forward(), settings.upward_shift);
     let scale = settings.scale;
-    let base = if settings.cached.is_none() {
+    let to_polyanya_polygon = |polygon: Vec<Vec2>| {
+        polygon
+            .into_iter()
+            .map(|v| to_polyanya_vec2(v / scale))
+            .collect::<Vec<_>>()
+    };
+    let base = if let Some(cached) = settings.cached {
+        cached
+    } else {
         let mut base = settings.fixed;
         base.set_agent_radius(settings.agent_radius);
         base.set_agent_radius_simplification(settings.simplify);
@@ -221,15 +229,13 @@ fn build_navmesh<T: ObstacleSource>(
                     .into_iter()
             })
             .filter(|p: &Vec<Vec2>| !p.is_empty())
-            .map(|p| p.into_iter().map(|v| v / scale).collect::<Vec<_>>());
+            .map(to_polyanya_polygon);
         base.add_obstacles(obstacle_polys);
         if settings.simplify != 0.0 {
             base.simplify(settings.simplify);
         }
         base.prebuild();
         base
-    } else {
-        settings.cached.unwrap()
     };
     let mut triangulation = base.clone();
 
@@ -241,7 +247,7 @@ fn build_navmesh<T: ObstacleSource>(
                 .into_iter()
         })
         .filter(|p: &Vec<Vec2>| !p.is_empty())
-        .map(|p| p.into_iter().map(|v| v / scale).collect::<Vec<_>>());
+        .map(to_polyanya_polygon);
     triangulation.add_obstacles(obstacle_polys);
 
     if settings.simplify != 0.0 {
@@ -254,7 +260,7 @@ fn build_navmesh<T: ObstacleSource>(
     }
     #[cfg(feature = "detailed-layers")]
     {
-        layer.scale = scale;
+        layer.scale = to_polyanya_vec2(scale);
     }
     layer.remove_useless_vertices();
     (
@@ -437,7 +443,7 @@ fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
                 cachable_obstacles
                     .iter()
                     .filter_map(|(e, t, o, _)| {
-                        (!settings.ignore_obstacles.contains(&e)).then_some((*t, o.clone()))
+                        (!settings.ignore_obstacles.contains(&e)).then_some((*t, (*o).clone()))
                     })
                     .collect::<Vec<_>>()
             } else {
@@ -446,7 +452,8 @@ fn trigger_navmesh_build<Marker: Component, Obstacle: ObstacleSource>(
             let obstacles_local = dynamic_obstacles
                 .iter()
                 .filter_map(|(e, t, o)| {
-                    (!settings.ignore_obstacles.contains(&e)).then_some((*t, o.clone()))
+                    (!settings.ignore_obstacles.contains(&e))
+                        .then_some((*t, o.into_inner().clone()))
                 })
                 .collect::<Vec<_>>();
             let settings_local = settings.clone();
@@ -568,7 +575,8 @@ fn update_navmesh_asset(
                 mesh.remove_stitches_to_layer(*layer_id);
                 mesh.layers[*layer_id as usize] = layer;
                 // TODO: rotate this to get the value in the correct space
-                mesh.layers[*layer_id as usize].offset = global_transform.translation().xz();
+                mesh.layers[*layer_id as usize].offset =
+                    to_polyanya_vec2(global_transform.translation().xz());
 
                 let stitch_segments =
                     settings
@@ -598,12 +606,12 @@ fn update_navmesh_asset(
                     let layer_to = &mesh.layers[*target_layer as usize];
 
                     let indices_from = layer_from.get_vertices_on_segment(
-                        stitch_segment[0] - layer_from.offset,
-                        stitch_segment[1] - layer_from.offset,
+                        to_polyanya_vec2(stitch_segment[0]) - layer_from.offset,
+                        to_polyanya_vec2(stitch_segment[1]) - layer_from.offset,
                     );
                     let indices_to = layer_to.get_vertices_on_segment(
-                        stitch_segment[0] - layer_to.offset,
-                        stitch_segment[1] - layer_to.offset,
+                        to_polyanya_vec2(stitch_segment[0]) - layer_to.offset,
+                        to_polyanya_vec2(stitch_segment[1]) - layer_to.offset,
                     );
                     if indices_from.len() != indices_to.len() {
                         debug!(
@@ -615,10 +623,8 @@ fn update_navmesh_asset(
                         continue 'stitching;
                     }
 
-                    let stitch_indices = indices_from
-                        .into_iter()
-                        .zip(indices_to.into_iter())
-                        .collect::<Vec<_>>();
+                    let stitch_indices =
+                        indices_from.into_iter().zip(indices_to).collect::<Vec<_>>();
                     for indices in &stitch_indices {
                         if (layer_from.vertices[indices.0].coords + layer_from.offset)
                             .distance_squared(layer_to.vertices[indices.1].coords + layer_to.offset)
@@ -652,7 +658,7 @@ fn update_navmesh_asset(
                     navmeshes
                         .insert(&handle.0, navmesh)
                         .expect("Failed to update navmesh");
-                } else if let Some(navmesh) = navmeshes.get_mut(&handle.0) {
+                } else if let Some(mut navmesh) = navmeshes.get_mut(&handle.0) {
                     failed_stitches.extend(previously_failed);
                     failed_stitches.sort_unstable();
                     failed_stitches.dedup();
@@ -688,7 +694,7 @@ fn update_navmesh_asset(
 ///
 /// # Example
 ///
-/// When using [`Aabb`](bevy::camera::primitives::Aabb) as the obstacle shape, the [`Obstacle`] component should be [`Aabb`](bevy::render::primitives::Aabb), and you should use a `Marker` component type of your own to differentiate between entities that are obstacles and those that aren't.
+/// When using [`Aabb`](bevy::camera::primitives::Aabb) as the obstacle shape, the `Obstacle` component should be [`Aabb`](bevy::camera::primitives::Aabb), and you should use a `Marker` component type of your own to differentiate between entities that are obstacles and those that aren't.
 ///
 /// ```no_run
 /// use bevy::{


### PR DESCRIPTION
Updates the crate, examples, and docs for Bevy 0.19 and Avian 0.7.

**Breaking Change**: The main migration note is the `glam` split: Bevy and Polyanya now use different `glam` versions, so Polyanya-facing APIs can’t take Bevy `Vec2`/`Vec3` directly anymore. I added `NavVec2`, `NavVec3`, and `nav_vec2` for those cases.